### PR TITLE
Include runAsUser in podSecurityContext 

### DIFF
--- a/charts/backup-pvc-cronjob/values.yaml
+++ b/charts/backup-pvc-cronjob/values.yaml
@@ -14,13 +14,12 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
   # fsGroup: 2000
-
-securityContext: 
   runAsNonRoot: true
-  readOnlyRootFilesystem: true
-  # runAsUser: 8888
+  runAsUser: 1000
+
+securityContext: {}
 
 resources:
   limits:


### PR DESCRIPTION
The job was failing because it was attempting to run as the root user while `runAsNonRoot` was set. I set the user in the `podSecurityContext` to 1000, the same as in the jenkinsci helm chart that we use, so that it will work for the jenkins cronjob and we can override it if we need to in future deployments.