### PR TITLE
Update image version for ambassador; add apps to pod-reaper

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,16 +14,16 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.1
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.3.0
+appVersion: 2.4.0
 
 dependencies:
   - name: ambassador
     condition: ambassador.enabled
-    version: 0.1.11
+    version: 0.2.0
   - name: appstore
     condition: appstore.enabled
     version: ^1
@@ -49,7 +49,7 @@ dependencies:
     version: 0.4.0
   - name: pod-reaper
     condition: pod-reaper.enabled
-    version: 0.2.0
+    version: 0.2.1
   - name: search
     condition: search.enabled
     version: ^1

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can view the README.md files for each subchart to see the variables that exi
 | global.tycho_api_service_name | string | `"helx-tycho-api"` |  |
 | image-utils.enabled | bool | `false` | enable/disable deployment of image-utils (imagepullsecret-patcher and imagepuller) |
 | monitoring.enabled | bool | `false` | enable/disable deployment of monitoring (kube-prometheus-stack, cost-analyzer, etc.) |
-| nfs-server.enabled | bool | `true` | enable/disable deployment of nfs-server |
+| nfs-server.enabled | bool | `false` | enable/disable deployment of nfs-server |
 | nfsrods.enabled | bool | `false` | enable/disable deployment of nfsrods |
 | nginx.enabled | bool | `true` | enable/disable deployment of nginx |
 | pod-reaper.enabled | bool | `true` | enable/disable deployment of pod-reaper |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/charts/ambassador/Chart.yaml
+++ b/charts/ambassador/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ambassador
-version: 0.1.11
-appVersion: 1.12.0
+version: 0.2.0
+appVersion: 1.14.4

--- a/charts/ambassador/README.md
+++ b/charts/ambassador/README.md
@@ -1,6 +1,6 @@
 # ambassador
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 1.14.4](https://img.shields.io/badge/AppVersion-1.14.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -17,12 +17,12 @@ A Helm chart for Kubernetes
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"250m"` |  |
+| resources.limits.cpu | string | `"300m"` |  |
 | resources.limits.ephemeral-storage | string | `"512Mi"` |  |
-| resources.limits.memory | string | `"300Mi"` |  |
-| resources.requests.cpu | string | `"150m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.ephemeral-storage | string | `"128Mi"` |  |
-| resources.requests.memory | string | `"130Mi"` |  |
+| resources.requests.memory | string | `"200Mi"` |  |
 | securityContext.runAsUser | int | `8888` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/ambassador/values.yaml
+++ b/charts/ambassador/values.yaml
@@ -28,12 +28,12 @@ securityContext:
 
 resources:
   limits:
-    cpu: 250m
-    memory: 300Mi
+    cpu: 300m
+    memory: 512Mi
     ephemeral-storage: 512Mi
   requests:
-    cpu: 150m
-    memory: 130Mi
+    cpu: 100m
+    memory: 200Mi
     ephemeral-storage: 128Mi
 
 global:

--- a/charts/pod-reaper/Chart.yaml
+++ b/charts/pod-reaper/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A Helm chart for pod-reaper
 name: pod-reaper
 home: https://github.com/target/pod-reaper
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.1.2

--- a/charts/pod-reaper/README.md
+++ b/charts/pod-reaper/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for pod-reaper
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
 
 ## Configuring Pod Reaper
 
@@ -67,7 +67,7 @@ reapers:
 | reapers.short-running-apps.log_level | string | `"Info"` |  |
 | reapers.short-running-apps.max_duration | string | `"1h"` |  |
 | reapers.short-running-apps.require_label_key | string | `"reaper-label"` |  |
-| reapers.short-running-apps.require_label_values | string | `"blackbalsam,cloud-top,dicom-cloudtop,dicom-gh,filebrowser,gsforge,imagej,jupyter-ds,napari,octave,jupyter-education,scout"` |  |
+| reapers.short-running-apps.require_label_values | string | `"blackbalsam,cloud-top,dicom-cloudtop,dicom-gh,filebrowser,gsforge,imagej,jupyter-datascience-db,jupyter-ds,jupyter-education,napari,octave,pgadmin,rstudio-server,scout,webtop-base,webtop-octave,webtop-pgadmin"` |  |
 | reapers.short-running-apps.run_duration | string | `"0s"` |  |
 | reapers.short-running-apps.schedule | string | `"@every 1m"` |  |
 | resources.limits.cpu | string | `"30m"` |  |

--- a/charts/pod-reaper/values.yaml
+++ b/charts/pod-reaper/values.yaml
@@ -14,7 +14,7 @@ reapers:
     schedule: "@every 1m"
     run_duration: "0s"
     require_label_key: "reaper-label"
-    require_label_values: "blackbalsam,cloud-top,dicom-cloudtop,dicom-gh,filebrowser,gsforge,imagej,jupyter-ds,napari,octave,jupyter-education,scout"
+    require_label_values: "blackbalsam,cloud-top,dicom-cloudtop,dicom-gh,filebrowser,gsforge,imagej,jupyter-datascience-db,jupyter-ds,jupyter-education,napari,octave,pgadmin,rstudio-server,scout,webtop-base,webtop-octave,webtop-pgadmin"
     dry_run: "false"
     log_level: "Info"
     log_format: "Logrus"

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ monitoring:
   enabled: false
 nfs-server:
   # -- enable/disable deployment of nfs-server
-  enabled: true
+  enabled: false
 nfsrods:
   # -- enable/disable deployment of nfsrods
   enabled: false


### PR DESCRIPTION
Changes were made along with the external-app-registry branch of appstore, but this merge isn't necessary for that.  pod-reaper changes are needed for chip690.