### PR TITLE
Decouple UI

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.9.2
+version: 1.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/nginx/templates/nginx-default-configmap.yaml
+++ b/charts/nginx/templates/nginx-default-configmap.yaml
@@ -23,6 +23,14 @@ data:
                 {{- end }}
                 server_name          {{ .Values.service.serverName }};
 
+                error_page 404 = @notfound;
+
+                location @notfound {
+                        if ($request_uri !~ "/helx") {
+                                rewrite ^/(.*)$ /helx/$1 last;
+                        }
+                }
+
                 location /private/ {
                          client_max_body_size 2000M;
                          proxy_http_version 1.1;
@@ -65,6 +73,7 @@ data:
                          {{- end }}
                          proxy_set_header X-Real-IP $remote_addr;
                          proxy_set_header X-Scheme $scheme;
+                         proxy_intercept_errors on;
                          proxy_connect_timeout   60s;
                          proxy_send_timeout      60s;
                          proxy_read_timeout 60s;

--- a/charts/nginx/templates/nginx-default-configmap.yaml
+++ b/charts/nginx/templates/nginx-default-configmap.yaml
@@ -23,8 +23,6 @@ data:
                 {{- end }}
                 server_name          {{ .Values.service.serverName }};
 
-                error_page 404 = @notfound;
-
                 location @notfound {
                         if ($request_uri !~ "/helx") {
                                 rewrite ^/(.*)$ /helx/$1 last;
@@ -73,13 +71,14 @@ data:
                          {{- end }}
                          proxy_set_header X-Real-IP $remote_addr;
                          proxy_set_header X-Scheme $scheme;
-                         proxy_intercept_errors on;
                          proxy_connect_timeout   60s;
                          proxy_send_timeout      60s;
                          proxy_read_timeout 60s;
                          proxy_http_version 1.1;
                          proxy_pass http://{{ .Values.global.ambassador_service_name }}:80;
                          proxy_set_header requestUri $request_uri;
+                         proxy_intercept_errors on;
+                         error_page 404 = @notfound;
                 }
 
                 {{- if .Values.restartrApi }}


### PR DESCRIPTION
- Update nginx default config to reroute 404s to the UI
- This is only enabled on appstore routes (`location / { ... }` block) so other location blocks such as app routing (`/private`) should still have their own 404 handling like before as long as proxy error handling isn’t enabled