### PR TITLE
Adding ingressClassName to basic resty ingress config

### DIFF
--- a/charts/resty/templates/ingress.yaml
+++ b/charts/resty/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: "{{ .Values.ingress.ingressClassName }}"
+{{- end}}
 {{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:


### PR DESCRIPTION
Need ingressClassName setting for normal ingress creation in Azure. Seems like this should have already been there also.