### PR TITLE
add sidecar container to run logrotate for ambassador log

### DIFF
--- a/charts/ambassador/README.md
+++ b/charts/ambassador/README.md
@@ -15,6 +15,9 @@ A Helm chart for Kubernetes
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/datawire/ambassador"` |  |
 | imagePullSecrets | list | `[]` |  |
+| logrotateImage.pullPolicy | string | `"IfNotPresent"` |  |
+| logrotateImage.repository | string | `"containers.renci.org/helxplatform/logrotate"` |  |
+| logrotateImage.tag | string | `"v0.0.1"` |  |
 | nameOverride | string | `""` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"300m"` |  |

--- a/charts/ambassador/templates/deployment.yaml
+++ b/charts/ambassador/templates/deployment.yaml
@@ -64,6 +64,24 @@ spec:
         volumeMounts:
         - mountPath: /tmp/ambassador-pod-info
           name: ambassador-pod-info
+        - name: shared-tmp-volume
+          mountPath: /tmp
+      - name: logrotate
+        image: "{{ .Values.logrotateImage.repository }}:{{ .Values.logrotateImage.tag }}"
+        imagePullPolicy: {{ .Values.logrotateImage.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          while true; do 
+            /usr/sbin/logrotate -s /tmp/logrotate.status /etc/logrotate.d/logrotate.conf; 
+            sleep 3600;
+          done
+        volumeMounts:
+        - name: logrotate-config-volume
+          mountPath: /etc/logrotate.d
+        - name: shared-tmp-volume
+          mountPath: /tmp
       restartPolicy: Always
       {{- if .Values.securityContext }}
       securityContext:
@@ -85,3 +103,8 @@ spec:
               fieldPath: metadata.labels
             path: labels
         name: ambassador-pod-info
+      - name: logrotate-config-volume
+        configMap:
+          name: logrotate-config
+      - name: shared-tmp-volume
+        emptyDir: {}

--- a/charts/ambassador/templates/logrotate-configmap.yaml
+++ b/charts/ambassador/templates/logrotate-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logrotate-config
+data:
+  logrotate.conf: |
+    /tmp/admin_access_log {
+      size 25M
+      copytruncate
+      rotate 5
+      compress
+      delaycompress
+      missingok
+      notifempty
+    }

--- a/charts/ambassador/values.yaml
+++ b/charts/ambassador/values.yaml
@@ -10,6 +10,11 @@ image:
   # tag: 1.1.1
   pullPolicy: IfNotPresent
 
+logrotateImage:
+  repository: containers.renci.org/helxplatform/logrotate
+  tag: v0.0.1
+  pullPolicy: IfNotPresent
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
I've added a sidecar container that will run logrotate every hour to rotate the log at /tmp/admin_access_log within the ambassador container.  I'm not totally certain that the /tmp/admin_access_log is the only log file that exists in the ambassador container, but it is the one I found and it does increase in size.  Once it hits the 256Mb limit for ephemeral storage then the pod would be terminated and another one created.  I also added a new github repository for the very simple logrotate image.