### PR TITLE
Adding allowPrivilegeEscalation: false security context to ambassador

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for deploying HeLx to Kubernetes.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.5.3
+version: 4.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 4.5.3](https://img.shields.io/badge/Version-4.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
+![Version: 4.5.4](https://img.shields.io/badge/Version-4.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/charts/ambassador/Chart.yaml
+++ b/charts/ambassador/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ambassador
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.14.4

--- a/charts/ambassador/README.md
+++ b/charts/ambassador/README.md
@@ -1,6 +1,6 @@
 # ambassador
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: 1.14.4](https://img.shields.io/badge/AppVersion-1.14.4-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: 1.14.4](https://img.shields.io/badge/AppVersion-1.14.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/ambassador/templates/deployment.yaml
+++ b/charts/ambassador/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
           value: "true"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /ambassador/v0/check_alive
@@ -69,6 +71,8 @@ spec:
       - name: logrotate
         image: "{{ .Values.logrotateImage.repository }}:{{ .Values.logrotateImage.tag }}"
         imagePullPolicy: {{ .Values.logrotateImage.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Adding allowPrivilegeEscalation: false security context to ambassador container definitions. this is needed so that the deployment is Azure policy compliant.

also bumping versions to 4.5.4 and 0.2.3 for the deployment.

If worthy, please merge and remove the branch.