### PR TITLE
Prototype/remove ambassador

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: "^0.2.0"
   - name: appstore
     condition: appstore.enabled
-    version: "^5.1.1"
+    version: "^5.0.0"
     repository: "@helx-charts"
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ You can view the README.md files for each subchart to see the variables that exi
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| ambassador | object | `{"enabled":true}` | ------------------------------------------------------------------------ |
 | ambassador.enabled | bool | `true` | enable/disable deployment of Ambassador |
 | appstore-sockets.enabled | bool | `true` | enable/disable deployment of appstore websockets service |
 | appstore.enabled | bool | `true` | enable/disable deployment of appstore |
+| appstore.tycho.appRoutingMode | string | `"ambassador"` | routing data plane for Tycho-launched apps: "ambassador" (default, legacy) or "proxy" (ClusterIP + /private, resolved by appstore via resty). Set to "proxy" when ambassador.enabled=false and resty.enabled=true. |
 | backup-pvc-cronjob.enabled | bool | `false` | enable/disable deployment of backup-pvc-cronjob |
 | global.ambassador_service_name | string | `"ambassador"` |  |
 | global.redis.existingSecret | string | `"redis-secret"` |  |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 4.5.4](https://img.shields.io/badge/Version-4.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
+![Version: 4.5.5](https://img.shields.io/badge/Version-4.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ You can view the README.md files for each subchart to see the variables that exi
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ambassador | object | `{"enabled":true}` | ------------------------------------------------------------------------ |
-| ambassador.enabled | bool | `true` | enable/disable deployment of Ambassador |
+| ambassador | object | `{"enabled":false}` | ------------------------------------------------------------------------ |
+| ambassador.enabled | bool | `false` | enable/disable deployment of Ambassador (retired in the de-Ambassador design) |
 | appstore-sockets.enabled | bool | `true` | enable/disable deployment of appstore websockets service |
 | appstore.enabled | bool | `true` | enable/disable deployment of appstore |
-| appstore.tycho.appRoutingMode | string | `"ambassador"` | routing data plane for Tycho-launched apps: "ambassador" (default, legacy) or "proxy" (ClusterIP + /private, resolved by appstore via resty). Set to "proxy" when ambassador.enabled=false and resty.enabled=true. |
+| appstore.tycho.appRoutingMode | string | `"proxy"` | routing data plane for Tycho-launched apps: "proxy" (ClusterIP + /private, resolved by appstore via resty) or "ambassador" (legacy). |
 | backup-pvc-cronjob.enabled | bool | `false` | enable/disable deployment of backup-pvc-cronjob |
 | global.ambassador_service_name | string | `"ambassador"` |  |
 | global.redis.existingSecret | string | `"redis-secret"` |  |
@@ -83,9 +83,9 @@ You can view the README.md files for each subchart to see the variables that exi
 | monitoring.enabled | bool | `false` | enable/disable deployment of monitoring (kube-prometheus-stack, cost-analyzer, etc.) |
 | nfs-server.enabled | bool | `false` | enable/disable deployment of nfs-server |
 | nfsrods.enabled | bool | `false` | enable/disable deployment of nfsrods |
-| nginx.enabled | bool | `true` | enable/disable deployment of nginx |
+| nginx.enabled | bool | `false` | enable/disable deployment of nginx (retired; replaced by resty) |
 | pod-reaper.enabled | bool | `true` | enable/disable deployment of pod-reaper |
-| resty.enabled | bool | `false` | enable/disable deployment of nginx |
+| resty.enabled | bool | `true` | enable/disable deployment of resty (the edge/data plane; replaces nginx) |
 | search.enabled | bool | `false` | enable/disable deployment of search |
 | ui.enabled | bool | `true` | enable/disable deployment of helx-ui |
 

--- a/charts/resty/README.md
+++ b/charts/resty/README.md
@@ -13,12 +13,19 @@ A Helm chart for Kubernetes
 | basicAuth | object | `{"enabled":false,"password":"defaultPassword","username":"defaultUser"}` | Creates a basicAuth scheme preventing un-authenticated access to the whole site. |
 | basicAuth.password | string | `"defaultPassword"` | Password, make sure to override. |
 | basicAuth.username | string | `"defaultUser"` | Username , make sure to override. |
+| dnsResolver | string | `"kube-dns.kube-system.svc.cluster.local"` | PROTOTYPE (ambassador removal): cluster DNS used to re-resolve the dynamic /private/ upstreams at request time. Must point at your cluster DNS (CoreDNS/kube-dns). Some nginx builds require an IP here rather than a name -- set the CoreDNS service ClusterIP if the hostname form fails. |
 | external_http_host | bool | `false` | If using an external http proxy host set this to true and specify serverName.  Used for TACC. |
 | fullnameOverride | string | `""` |  |
+| global.airflow_service_name | string | `"airflow-webserver"` |  |
 | global.ambassador_service_name | string | `"ambassador"` |  |
+| global.apps_namespace | string | `""` | Namespace where Tycho launches app pods (for /private DNS names). Defaults to the release namespace when empty. |
+| global.appstore_service_name | string | `"appstore"` | PROTOTYPE (ambassador removal): direct backend service names that were previously reached only through the "ambassador" service. Set these to match your appstore / ui / sockets Service names. |
+| global.appstore_sockets_service_name | string | `"appstore-sockets-service"` |  |
+| global.cluster_dns_suffix | string | `"svc.cluster.local"` |  |
 | global.dug_search_client_service_name | string | `"dug-search-client"` |  |
 | global.dug_web_service_name | string | `"dug-web"` |  |
 | global.restartr_api_service_name | string | `"restartr-api-service"` |  |
+| global.ui_service_name | string | `"helx-ui"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"bitnami/openresty"` |  |
 | image.tag | float | `1.21` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/resty/templates/nginx-default-configmap.yaml
+++ b/charts/resty/templates/nginx-default-configmap.yaml
@@ -180,6 +180,16 @@ data:
         proxy_pass http://$upstream$upstream_uri;
         proxy_pass_request_headers      on;
 
+        # Forward the real client context. With a variable upstream, nginx
+        # would otherwise send Host = the backend Service DNS name; apps like
+        # pgAdmin build URLs / cookies / CSRF context from these, so preserve
+        # the external host and scheme exactly as Ambassador/Envoy did.
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
         # websocket upgrades (jupyter kernels, rstudio, webtop, guacamole)
         proxy_buffering off;
         proxy_set_header Upgrade $http_upgrade;

--- a/charts/resty/templates/nginx-default-configmap.yaml
+++ b/charts/resty/templates/nginx-default-configmap.yaml
@@ -112,6 +112,7 @@ data:
 
         set $upstream '';
         set $upstream_uri '';
+        set $location_prefix '';
 
         {{- if .Values.DEV_PHASE.dev }}
         # dev: appstore/tycho run locally, no in-cluster resolution.
@@ -147,6 +148,10 @@ data:
 
           local uri = ngx.var.request_uri
           if rewrite ~= "" then
+            -- Stripped apps (rstudio, webtop, cloudbeaver, ...) think they
+            -- live at "/", so their 3xx Location headers are root-relative.
+            -- Remember the prefix so header_filter_by_lua can re-add it.
+            ngx.var.location_prefix = prefix:gsub("/$", "")
             -- Strip the app prefix and serve under the rewrite target
             -- (e.g. rstudio's proxy-rewrite target "/"). Tolerate a
             -- missing trailing slash on the matched prefix.
@@ -194,6 +199,26 @@ data:
         proxy_buffering off;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
+
+        # For stripped apps, re-add the /private/{app}/{user}/{guid} prefix to
+        # redirect Location headers (the app emits root-relative/same-host
+        # redirects because it thinks it lives at "/"). This is what Ambassador
+        # + the old nginx did via X-Original-Path.
+        header_filter_by_lua_block {
+          local lp = ngx.var.location_prefix
+          if lp ~= "" and ngx.status >= 300 and ngx.status < 400 then
+            local loc = ngx.header["Location"]
+            if loc and loc ~= "" then
+              -- drop scheme://host from same-origin absolute URLs
+              local path = loc:gsub("^https?://[^/]+", "")
+              -- only rewrite root-relative paths not already under the prefix
+              if path:sub(1, 1) == "/" and path:sub(1, 2) ~= "//"
+                 and path:sub(1, #lp) ~= lp then
+                ngx.header["Location"] = lp .. path
+              end
+            end
+          end
+        }
       }
 
       # ---- internal resolver subrequest -> appstore control plane ----

--- a/charts/resty/templates/nginx-default-configmap.yaml
+++ b/charts/resty/templates/nginx-default-configmap.yaml
@@ -4,6 +4,33 @@ metadata:
   name: {{ .Release.Name }}-default-nginx-conf
 data:
   default.conf: |
+    #####################################################################
+    # PROTOTYPE: Ambassador-free routing.
+    #
+    # Ambassador used to be an internal ClusterIP prefix-router that this
+    # OpenResty instance forwarded almost everything to (ambassador:80).
+    # It did no TLS and no auth of its own -- it only fanned requests out
+    # to backend services by path prefix, including one dynamically
+    # created Mapping per launched app (/private/{app}/{user}/{guid}).
+    #
+    # Because a launched app's Kubernetes Service name is a pure function
+    # of the URL path ({app}-{guid}, see Tycho model.py System.name), we
+    # can resolve and proxy to it directly from OpenResty with cluster DNS
+    # -- no Ambassador, no per-app config, no reloads. Static services
+    # (appstore / ui / sockets) become explicit location blocks below.
+    #####################################################################
+
+    # Cluster DNS is required so proxy_pass to a *variable* upstream is
+    # re-resolved at request time (that is what makes /private dynamic).
+    # Override with resty.dnsResolver if your cluster DNS differs.
+    resolver {{ .Values.dnsResolver | default "kube-dns.kube-system.svc.cluster.local" }} valid=10s ipv6=off;
+
+    {{- $appstore := printf "%s:8000" (.Values.global.appstore_service_name | default "appstore") }}
+    {{- $ui := printf "%s:80" (.Values.global.ui_service_name | default "helx-ui") }}
+    {{- $sockets := printf "%s:5555" (.Values.global.appstore_sockets_service_name | default "appstore-sockets-service") }}
+    {{- $appsNamespace := .Values.global.apps_namespace | default .Release.Namespace }}
+    {{- $dnsSuffix := .Values.global.cluster_dns_suffix | default "svc.cluster.local" }}
+
     {{- if and (.Values.SSL) (not .Values.ingress.create) }}
     server {
       listen      {{ .Values.service.httpTargetPort }} default_server;
@@ -29,107 +56,153 @@ data:
         }
       }
 
+      # ---- helx-ui (was Ambassador Mapping: prefix /helx) ----
+      location /helx {
+        client_max_body_size 2000M;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_pass http://{{ $ui }};
+        proxy_set_header requestUri $request_uri;
+      }
+
+      # ---- helx-ui static assets (was Ambassador Mapping: /static/frontend) ----
+      location /static/frontend {
+        client_max_body_size 2000M;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_pass http://{{ $ui }};
+      }
+
+      # ---- appstore-sockets status websocket (was Ambassador Mapping: /ws) ----
       location /ws {
         client_max_body_size 2000M;
         proxy_http_version 1.1;
         proxy_read_timeout 3600;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_pass http://{{ .Values.global.ambassador_service_name }}:80$request_uri;
+        proxy_pass http://{{ $sockets }}$request_uri;
         proxy_pass_request_headers      on;
       }
 
       #####################################################
-      # Location /private
+      # Location /private  (DYNAMIC -- replaces Ambassador's per-app Mapping)
       #
-      # Purpose:
-      # This block handles requests to paths starting with "/private/". It contains
-      # configurations for body size, proxy settings, authentication, header 
-      # modifications, and dynamic redirection handling.
+      # URL shape (unchanged, the UI parses it positionally):
+      #   /private/{app}/{user}/{guid}/{conn_string}/...
       #
-      # Details:
-      # - Sets the maximum allowed size of the client request body to 2000M.
-      # - Configures proxy settings including timeouts and header modifications.
-      # - Fetches dynamic value for Ambassador service name.
-      # - Contains specific settings for the Guacamole application.
-      # 
-      # REMOTE_USER and Authentication:
-      # - Uses the auth_request directive to perform subrequest authentication. Access
-      #   is allowed if subrequest returns a 2xx response, otherwise denied.
-      # - Captures authenticated user's name from the upstream's `REMOTE_USER` header 
-      #   and sets it to the Nginx variable `$remoteUser`.
-      # - This `$remoteUser` is then set as the `REMOTE_USER` header for the proxied
-      #   request, informing the downstream service of the requesting user.
-      # - Additionally, fetches access token from the upstream's `access_token` header
-      #   for further authorization.
-      #
-      # Lua Script Function:
-      # - The Lua script triggers during the header filtering phase.
-      # - Checks if the response is a redirect (HTTP status in the 3xx range).
-      # - Fetches the `X-Original-Path` and `Location` headers from upstream response.
-      # - Modifies `Location` header by:
-      #   1. Concatenating the `X-Original-Path` value (if present).
-      #   2. Removing the "https?://ambassador/" substring from the URL.
-      # - Sets the modified `Location` header for client's response, redirecting 
-      #   client to the correct modified URL.
-      #
-      # Note:
-      # - Configurations conditionally set based on .Values.DEV_PHASE.dev value.
-      # - Guacamole-specific settings disable buffering and set headers for WebSocket.
-      #
+      # For each request we ask appstore (the control plane) to resolve the
+      # backend. appstore is authoritative: it verifies the user OWNS this
+      # system (a check Ambassador never did -- it set bypass_auth: true) and
+      # returns the backend Service host, its real port, and the per-app
+      # rewrite rule. We then proxy over cluster DNS. This subrequest fires
+      # at the same frequency Ambassador's auth_request already did, so it
+      # adds no round-trip versus the old flow.
       #####################################################
-
-      location /private/ {
+      location ~ ^/private/(?<app>[^/]+)/(?<user>[^/]+)/(?<guid>[^/]+)(?<rest>/.*)?$ {
         client_max_body_size 2000M;
         proxy_http_version 1.1;
         proxy_read_timeout 3600;
+
+        set $upstream '';
+        set $upstream_uri '';
+
         {{- if .Values.DEV_PHASE.dev }}
+        # dev: appstore/tycho run locally, no in-cluster resolution.
         {{- else }}
-        auth_request /auth;
-        auth_request_set $remoteUser $upstream_http_remote_user;
-        proxy_set_header REMOTE_USER $remoteUser;
-        add_header REMOTE_USER $remoteUser;
-        auth_request_set $access_token $upstream_http_access_token;
-        proxy_set_header Authorization $access_token;
-        add_header Authorization $access_token;
+        access_by_lua_block {
+          -- Ask appstore to authorize + resolve this /private URL. Cookies
+          -- are inherited by the subrequest; pass the original path along.
+          local res = ngx.location.capture(
+            "/appstore-resolve",
+            { args = { uri = ngx.var.request_uri } }
+          )
+          if res.status ~= 200 then
+            -- 403 (not owner), 404 (not ready), 5xx (resolve failed)
+            ngx.exit(res.status)
+          end
+
+          local h = res.header
+          local host    = h["X-Backend-Host"]
+          local port    = h["X-Backend-Port"]
+          local rewrite = h["X-Rewrite"] or ""
+          local prefix  = h["X-Prefix"] or ""
+
+          if not host or not port then
+            ngx.log(ngx.ERR, "private resolve: missing backend host/port")
+            ngx.exit(502)
+          end
+
+          ngx.var.upstream = host .. ".{{ $appsNamespace }}.{{ $dnsSuffix }}:" .. port
+
+          local uri = ngx.var.request_uri
+          if rewrite ~= "" then
+            -- Strip the app prefix and serve under the rewrite target
+            -- (e.g. rstudio's proxy-rewrite target "/"). Tolerate a
+            -- missing trailing slash on the matched prefix.
+            local stripped = uri
+            if prefix ~= "" and uri:sub(1, #prefix) == prefix then
+              stripped = uri:sub(#prefix + 1)
+            else
+              local p2 = prefix:gsub("/$", "")
+              if #p2 > 0 and uri:sub(1, #p2) == p2 then
+                stripped = uri:sub(#p2 + 1)
+              end
+            end
+            if stripped == "" then
+              ngx.var.upstream_uri = rewrite
+            elseif rewrite:sub(-1) == "/" and stripped:sub(1, 1) == "/" then
+              ngx.var.upstream_uri = rewrite .. stripped:sub(2)
+            else
+              ngx.var.upstream_uri = rewrite .. stripped
+            end
+          else
+            -- Preserve full path (prefix-aware apps: jupyter, pgadmin, ...)
+            ngx.var.upstream_uri = uri
+          end
+
+          -- Inject identity downstream, as Ambassador's REMOTE_USER header did.
+          ngx.req.set_header("REMOTE_USER", h["REMOTE_USER"] or "")
+          ngx.req.set_header("Authorization", h["ACCESS_TOKEN"] or "")
+        }
         {{- end }}
-        proxy_pass http://{{ .Values.global.ambassador_service_name }}:80$request_uri;
+
+        proxy_pass http://$upstream$upstream_uri;
         proxy_pass_request_headers      on;
-        # for guacamole
+
+        # websocket upgrades (jupyter kernels, rstudio, webtop, guacamole)
         proxy_buffering off;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
-        # end guacamole additons
-
-        header_filter_by_lua_block {
-          -- Check if the response is a redirect
-          if ngx.status >= 300 and ngx.status < 400 then
-            local original_path = ngx.var.upstream_http_x_original_path
-            local location = ngx.var.upstream_http_location
-      
-            ngx.log(ngx.INFO, "Status code: ", ngx.status)
-            ngx.log(ngx.INFO, "X-Original-Path header: ", original_path or "not set")
-            ngx.log(ngx.INFO, "Location header: ", location or "not set")
-      
-            if original_path and location then
-              local new_location = original_path .. location:gsub("https?://{{ .Values.global.ambassador_service_name }}/", "")
-              ngx.log(ngx.INFO, "New Location after transformation: ", new_location)
-              ngx.header["Location"] = new_location
-            end
-          end
-        }
       }
 
+      # ---- internal resolver subrequest -> appstore control plane ----
+      # Verifies ownership and returns backend host/port + rewrite headers.
+      location = /appstore-resolve {
+        internal;
+        proxy_pass http://{{ $appstore }}/api/v1/private-route/;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        # Original app path the browser requested (see access_by_lua args).
+        proxy_set_header X-Original-URI $arg_uri;
+        proxy_read_timeout 30;
+      }
+
+      # ---- auth decision endpoint (was ambassador:80/auth/ -> appstore) ----
+      # Now points straight at appstore Django, which owns the auth logic.
       location = /auth {
+        internal;
         client_max_body_size 2000M;
         proxy_http_version 1.1;
-        proxy_pass http://{{ .Values.global.ambassador_service_name }}:80/auth/;
+        proxy_pass http://{{ $appstore }}/auth/;
         proxy_read_timeout 3600;
         proxy_pass_request_body off;
         proxy_set_header        Content-Length "";
         proxy_set_header        X-Original-URI $request_uri;
       }
 
+      # ---- appstore catch-all (was Ambassador Mapping: prefix /) ----
       location / {
         client_max_body_size 2000M;
         {{- if .Values.external_http_host }}
@@ -143,7 +216,7 @@ data:
         proxy_send_timeout      60s;
         proxy_read_timeout 60s;
         proxy_http_version 1.1;
-        proxy_pass http://{{ .Values.global.ambassador_service_name }}:80;
+        proxy_pass http://{{ $appstore }};
         proxy_set_header requestUri $request_uri;
         proxy_intercept_errors on;
         error_page 404 = @notfound;
@@ -167,8 +240,6 @@ data:
         proxy_http_version 1.1;
         proxy_pass http://{{ .Values.global.restartr_api_service_name }}:5552/;
         proxy_set_header requestUri $request_uri;
-        #proxy_intercept_errors on;
-        #error_page 404 = @fallback;
       }
 
       location /api/ {
@@ -178,16 +249,10 @@ data:
         proxy_http_version 1.1;
         proxy_pass http://{{ .Values.global.restartr_api_service_name }}:5552$request_uri;
         proxy_set_header requestUri $request_uri;
-        #proxy_intercept_errors on;
-        #error_page 404 = @fallback;
       }
-
-      #location @fallback {
-      #        try_files /var/www/flasgger/flasgger/ui3/static/ =500;
-      #}
       {{- end }}
 
-      # Makes /airflow/ accessible if not authenticated
+      # ---- airflow (was proxied via ambassador) ----
       location /airflow {
         proxy_http_version 1.1;
         {{- if .Values.DEV_PHASE.dev }}
@@ -203,7 +268,7 @@ data:
         {{- end }}
         {{- end }}
         proxy_set_header Host $http_host;
-        proxy_pass http://{{ .Values.global.ambassador_service_name }}:80$request_uri;
+        proxy_pass http://{{ .Values.global.airflow_service_name | default "airflow-webserver" }}:8080$request_uri;
         proxy_pass_request_headers  on;
       }
 

--- a/charts/resty/templates/nginx-default-configmap.yaml
+++ b/charts/resty/templates/nginx-default-configmap.yaml
@@ -25,11 +25,16 @@ data:
     # Override with resty.dnsResolver if your cluster DNS differs.
     resolver {{ .Values.dnsResolver | default "kube-dns.kube-system.svc.cluster.local" }} valid=10s ipv6=off;
 
-    {{- $appstore := printf "%s:8000" (.Values.global.appstore_service_name | default "appstore") }}
-    {{- $ui := printf "%s:80" (.Values.global.ui_service_name | default "helx-ui") }}
-    {{- $sockets := printf "%s:5555" (.Values.global.appstore_sockets_service_name | default "appstore-sockets-service") }}
     {{- $appsNamespace := .Values.global.apps_namespace | default .Release.Namespace }}
     {{- $dnsSuffix := .Values.global.cluster_dns_suffix | default "svc.cluster.local" }}
+    {{- /* Use FQDNs: any proxy_pass containing a variable (e.g. $request_uri)
+           resolves via the `resolver` directive, which does not apply the
+           pod's DNS search domains -- bare service names fail. Platform
+           services are assumed to live in the same namespace as launched apps. */}}
+    {{- $appstore := printf "%s.%s.%s:8000" (.Values.global.appstore_service_name | default "appstore") $appsNamespace $dnsSuffix }}
+    {{- $ui := printf "%s.%s.%s:80" (.Values.global.ui_service_name | default "helx-ui") $appsNamespace $dnsSuffix }}
+    {{- $sockets := printf "%s.%s.%s:5555" (.Values.global.appstore_sockets_service_name | default "appstore-sockets-service") $appsNamespace $dnsSuffix }}
+    {{- $airflow := printf "%s.%s.%s:8080" (.Values.global.airflow_service_name | default "airflow-webserver") $appsNamespace $dnsSuffix }}
 
     {{- if and (.Values.SSL) (not .Values.ingress.create) }}
     server {
@@ -124,17 +129,21 @@ data:
           end
 
           local h = res.header
-          local host    = h["X-Backend-Host"]
           local port    = h["X-Backend-Port"]
           local rewrite = h["X-Rewrite"] or ""
           local prefix  = h["X-Prefix"] or ""
 
-          if not host or not port then
-            ngx.log(ngx.ERR, "private resolve: missing backend host/port")
+          if not port then
+            ngx.log(ngx.ERR, "private resolve: missing backend port")
             ngx.exit(502)
           end
 
-          ngx.var.upstream = host .. ".{{ $appsNamespace }}.{{ $dnsSuffix }}:" .. port
+          -- The backend Service name is deterministic from the URL path:
+          -- {app}-{guid} (Tycho System.name = f"{app_id}-{identifier}").
+          -- Build it from the regex captures rather than trusting a
+          -- resolver-returned name, so it can't drift.
+          local svc = ngx.var.app .. "-" .. ngx.var.guid
+          ngx.var.upstream = svc .. ".{{ $appsNamespace }}.{{ $dnsSuffix }}:" .. port
 
           local uri = ngx.var.request_uri
           if rewrite ~= "" then
@@ -268,7 +277,7 @@ data:
         {{- end }}
         {{- end }}
         proxy_set_header Host $http_host;
-        proxy_pass http://{{ .Values.global.airflow_service_name | default "airflow-webserver" }}:8080$request_uri;
+        proxy_pass http://{{ $airflow }}$request_uri;
         proxy_pass_request_headers  on;
       }
 

--- a/charts/resty/values.yaml
+++ b/charts/resty/values.yaml
@@ -90,8 +90,25 @@ stubStatus:
   localhostOnly: true
   stubStatusLocation: "/nginx_status"
 
+# -- PROTOTYPE (ambassador removal): cluster DNS used to re-resolve the
+# dynamic /private/ upstreams at request time. Must point at your cluster
+# DNS (CoreDNS/kube-dns). Some nginx builds require an IP here rather than
+# a name -- set the CoreDNS service ClusterIP if the hostname form fails.
+dnsResolver: kube-dns.kube-system.svc.cluster.local
+
 global:
   ambassador_service_name: ambassador
   dug_web_service_name: dug-web
   dug_search_client_service_name: dug-search-client
   restartr_api_service_name: restartr-api-service
+  # -- PROTOTYPE (ambassador removal): direct backend service names that
+  # were previously reached only through the "ambassador" service. Set
+  # these to match your appstore / ui / sockets Service names.
+  appstore_service_name: appstore
+  ui_service_name: helx-ui
+  appstore_sockets_service_name: appstore-sockets-service
+  airflow_service_name: airflow-webserver
+  # -- Namespace where Tycho launches app pods (for /private DNS names).
+  # Defaults to the release namespace when empty.
+  apps_namespace: ""
+  cluster_dns_suffix: svc.cluster.local

--- a/values.yaml
+++ b/values.yaml
@@ -1,11 +1,23 @@
 # Parent chart for HeLx.
 
+# --------------------------------------------------------------------------
+# Removing Ambassador (route launched apps via appstore + resty instead):
+#   ambassador.enabled: false
+#   resty.enabled: true                    # de-Ambassador resty config (data plane)
+#   appstore.tycho.appRoutingMode: proxy   # appstore becomes the routing control plane
+# See the appstore repo: spec/ambassador-removal.md (§11 enablement runbook).
+# --------------------------------------------------------------------------
 ambassador:
   # -- enable/disable deployment of Ambassador
   enabled: true
 appstore:
   # -- enable/disable deployment of appstore
   enabled: true
+  tycho:
+    # -- routing data plane for Tycho-launched apps: "ambassador" (default,
+    # legacy) or "proxy" (ClusterIP + /private, resolved by appstore via resty).
+    # Set to "proxy" when ambassador.enabled=false and resty.enabled=true.
+    appRoutingMode: ambassador
 backup-pvc-cronjob:
   # -- enable/disable deployment of backup-pvc-cronjob
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -1,23 +1,23 @@
 # Parent chart for HeLx.
 
 # --------------------------------------------------------------------------
-# Removing Ambassador (route launched apps via appstore + resty instead):
-#   ambassador.enabled: false
-#   resty.enabled: true                    # de-Ambassador resty config (data plane)
-#   appstore.tycho.appRoutingMode: proxy   # appstore becomes the routing control plane
+# De-Ambassador configuration (this branch's target state):
+#   Ambassador is removed; resty is the edge/data plane (it replaces nginx,
+#   which is being retired entirely); appstore is the routing control plane.
+#   To fall back to the legacy Ambassador path: ambassador.enabled=true,
+#   nginx.enabled=true, resty.enabled=false, appstore.tycho.appRoutingMode=ambassador.
 # See the appstore repo: spec/ambassador-removal.md (§11 enablement runbook).
 # --------------------------------------------------------------------------
 ambassador:
-  # -- enable/disable deployment of Ambassador
-  enabled: true
+  # -- enable/disable deployment of Ambassador (retired in the de-Ambassador design)
+  enabled: false
 appstore:
   # -- enable/disable deployment of appstore
   enabled: true
   tycho:
-    # -- routing data plane for Tycho-launched apps: "ambassador" (default,
-    # legacy) or "proxy" (ClusterIP + /private, resolved by appstore via resty).
-    # Set to "proxy" when ambassador.enabled=false and resty.enabled=true.
-    appRoutingMode: ambassador
+    # -- routing data plane for Tycho-launched apps: "proxy" (ClusterIP +
+    # /private, resolved by appstore via resty) or "ambassador" (legacy).
+    appRoutingMode: proxy
 backup-pvc-cronjob:
   # -- enable/disable deployment of backup-pvc-cronjob
   enabled: false
@@ -36,14 +36,14 @@ nfsrods:
   # -- enable/disable deployment of nfsrods
   enabled: false
 nginx:
-  # -- enable/disable deployment of nginx
-  enabled: true
+  # -- enable/disable deployment of nginx (retired; replaced by resty)
+  enabled: false
 pod-reaper:
   # -- enable/disable deployment of pod-reaper
   enabled: true
 resty:
-  # -- enable/disable deployment of nginx
-  enabled: false
+  # -- enable/disable deployment of resty (the edge/data plane; replaces nginx)
+  enabled: true
 search:
   # -- enable/disable deployment of search
   enabled: false


### PR DESCRIPTION
Rework the resty (OpenResty) default config so no location proxies to ambassador:80. Static services get explicit backends (/helx + /static/frontend -> helx-ui, /ws -> appstore-sockets, / -> appstore, /airflow -> airflow), and /private is resolved dynamically:

- /private/{app}/{user}/{guid}/... runs an access_by_lua subrequest to appstore (/api/v1/private-route/) which authorizes the user and returns the backend host/port + rewrite. resty then proxies to {app}-{guid} over cluster DNS on its real port, preserving or rewriting the path per app. This fires at the same rate as the old auth_request, so no extra round-trip.
- Adds a resolver directive + dnsResolver value for dynamic upstreams, and global.{appstore,ui,appstore_sockets,airflow}_service_name / apps_namespace / cluster_dns_suffix knobs (backends were previously reached only via the ambassador service).