### PR TITLE
resty: default appstore_service_name to helx-appstore

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for deploying HeLx to Kubernetes.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.5.5
+version: 4.5.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 4.5.5](https://img.shields.io/badge/Version-4.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
+![Version: 4.5.6](https://img.shields.io/badge/Version-4.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/charts/resty/README.md
+++ b/charts/resty/README.md
@@ -19,13 +19,13 @@ A Helm chart for Kubernetes
 | global.airflow_service_name | string | `"airflow-webserver"` |  |
 | global.ambassador_service_name | string | `"ambassador"` |  |
 | global.apps_namespace | string | `""` | Namespace where Tycho launches app pods (for /private DNS names). Defaults to the release namespace when empty. |
-| global.appstore_service_name | string | `"appstore"` | PROTOTYPE (ambassador removal): direct backend service names that were previously reached only through the "ambassador" service. Set these to match your appstore / ui / sockets Service names. |
+| global.appstore_service_name | string | `nil` | PROTOTYPE (ambassador removal): direct backend service names that were previously reached only through the "ambassador" service. appstore_service_name / ui_service_name: leave null to auto-derive — the bare chart name ("appstore"/"ui") when resty is deployed on its own, or "<release>-appstore"/"<release>-ui" when deployed as a subchart of the umbrella. Set explicitly only if your Service names differ. |
 | global.appstore_sockets_service_name | string | `"appstore-sockets-service"` |  |
 | global.cluster_dns_suffix | string | `"svc.cluster.local"` |  |
 | global.dug_search_client_service_name | string | `"dug-search-client"` |  |
 | global.dug_web_service_name | string | `"dug-web"` |  |
 | global.restartr_api_service_name | string | `"restartr-api-service"` |  |
-| global.ui_service_name | string | `"helx-ui"` |  |
+| global.ui_service_name | string | `nil` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"bitnami/openresty"` |  |
 | image.tag | float | `1.21` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/resty/templates/nginx-default-configmap.yaml
+++ b/charts/resty/templates/nginx-default-configmap.yaml
@@ -31,8 +31,14 @@ data:
            resolves via the `resolver` directive, which does not apply the
            pod's DNS search domains -- bare service names fail. Platform
            services are assumed to live in the same namespace as launched apps. */}}
-    {{- $appstore := printf "%s.%s.%s:8000" (.Values.global.appstore_service_name | default "appstore") $appsNamespace $dnsSuffix }}
-    {{- $ui := printf "%s.%s.%s:80" (.Values.global.ui_service_name | default "helx-ui") $appsNamespace $dnsSuffix }}
+    {{- /* Default the appstore/ui Service names to the bare chart name when
+           resty is the root chart (deployed on its own), or "<release>-<name>"
+           when it is a subchart of the umbrella (Helm prefixes subchart Service
+           names with the release name). Override via global.*_service_name. */}}
+    {{- $appstoreDefault := ternary "appstore" (printf "%s-appstore" .Release.Name) .Chart.IsRoot }}
+    {{- $uiDefault := ternary "ui" (printf "%s-ui" .Release.Name) .Chart.IsRoot }}
+    {{- $appstore := printf "%s.%s.%s:8000" (.Values.global.appstore_service_name | default $appstoreDefault) $appsNamespace $dnsSuffix }}
+    {{- $ui := printf "%s.%s.%s:80" (.Values.global.ui_service_name | default $uiDefault) $appsNamespace $dnsSuffix }}
     {{- $sockets := printf "%s.%s.%s:5555" (.Values.global.appstore_sockets_service_name | default "appstore-sockets-service") $appsNamespace $dnsSuffix }}
     {{- $airflow := printf "%s.%s.%s:8080" (.Values.global.airflow_service_name | default "airflow-webserver") $appsNamespace $dnsSuffix }}
 

--- a/charts/resty/values.yaml
+++ b/charts/resty/values.yaml
@@ -102,10 +102,13 @@ global:
   dug_search_client_service_name: dug-search-client
   restartr_api_service_name: restartr-api-service
   # -- PROTOTYPE (ambassador removal): direct backend service names that
-  # were previously reached only through the "ambassador" service. Set
-  # these to match your appstore / ui / sockets Service names.
-  appstore_service_name: appstore
-  ui_service_name: helx-ui
+  # were previously reached only through the "ambassador" service.
+  # appstore_service_name / ui_service_name: leave null to auto-derive — the
+  # bare chart name ("appstore"/"ui") when resty is deployed on its own, or
+  # "<release>-appstore"/"<release>-ui" when deployed as a subchart of the
+  # umbrella. Set explicitly only if your Service names differ.
+  appstore_service_name:
+  ui_service_name:
   appstore_sockets_service_name: appstore-sockets-service
   airflow_service_name: airflow-webserver
   # -- Namespace where Tycho launches app pods (for /private DNS names).


### PR DESCRIPTION
Full disclosure, I'm back and forth on whether a default is worth having - this addresses an inconsistency I observed in deploying the de-ambassador changes though. 

The de-Ambassador resty config resolves static upstreams (proxy_pass without an nginx variable: /private-route, /auth, /) at startup and refuses to boot if one is unresolvable. The umbrella deploys with Release.Name=helx, so the appstore Service is "helx-appstore", but the default was plain "appstore" -> "host not found in upstream" CrashLoopBackOff. Match the ui_service_name: helx-ui convention so a stock `helm install` works without a --set override.

Chart version 4.5.5 -> 4.5.6.