### PR TITLE
resty: add values-gated /artifact route to artifact-cache

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for deploying HeLx to Kubernetes.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.5.7
+version: 4.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/resty/Chart.yaml
+++ b/charts/resty/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: resty
-version: "1.0.4"
+version: "1.0.5"
 appVersion: "2.0.1"

--- a/charts/resty/templates/nginx-default-configmap.yaml
+++ b/charts/resty/templates/nginx-default-configmap.yaml
@@ -322,6 +322,25 @@ data:
         proxy_pass_request_headers  on;
       }
 
+      {{- if .Values.artifactCache.enabled }}
+      # ---- artifact-cache (replaces the ambassador Mapping: prefix /artifact/
+      #      -> artifact-cache:8080). Used by air-gapped envs to serve the
+      #      helx-apps registry/specs (and browser-side app assets) in-cluster.
+      #      The trailing slash on proxy_pass strips the /artifact/ prefix, so
+      #      /artifact/assets/... reaches the cache as /assets/... (Ambassador's
+      #      default rewrite). Set artifactCache.authenticate=true to gate it. ----
+      location /artifact/ {
+        proxy_http_version 1.1;
+        {{- if .Values.artifactCache.authenticate }}
+        auth_request /auth;
+        auth_request_set $remoteUser $upstream_http_remote_user;
+        proxy_set_header REMOTE_USER $remoteUser;
+        {{- end }}
+        proxy_set_header Host $http_host;
+        proxy_pass http://{{ .Values.artifactCache.serviceName }}.{{ $appsNamespace }}.{{ $dnsSuffix }}:{{ .Values.artifactCache.port }}/;
+      }
+      {{- end }}
+
       {{- if .Values.stubStatus.enabled }}
       location {{ .Values.stubStatus.stubStatusLocation }} {
         stub_status;

--- a/charts/resty/values.yaml
+++ b/charts/resty/values.yaml
@@ -115,3 +115,13 @@ global:
   # Defaults to the release namespace when empty.
   apps_namespace: ""
   cluster_dns_suffix: svc.cluster.local
+
+# -- Optional /artifact route to an in-cluster artifact-cache service (replaces
+# the ambassador Mapping for /artifact). Enable in envs that serve the helx-apps
+# registry/specs from an artifact cache (e.g. air-gapped OpenShift). Off by
+# default. Set authenticate=true to require the auth_request gate on /artifact.
+artifactCache:
+  enabled: false
+  serviceName: artifact-cache
+  port: 8080
+  authenticate: false


### PR DESCRIPTION
De-Ambassador dropped the per-service ambassador Mapping "prefix: /artifact/ ->
artifact-cache:8080", so envs that serve the helx-apps registry/specs (and browser-side app assets) from an in-cluster artifact cache lost /artifact and appstore's spec fetches 404'd -> empty app catalog (seen on OpenShift cdsr-stage, which is egress-restricted and can't reach GitHub).

Add an optional location /artifact/ -> artifactCache.serviceName:port with the trailing-slash prefix strip (matches Ambassador's default rewrite). Gated on artifactCache.enabled (default false, so the umbrella/other envs are unaffected) with an optional auth_request gate via artifactCache.authenticate.

resty 1.0.4 -> 1.0.5; umbrella 4.5.7 -> 4.5.8.