### PR TITLE
bump chart version to pick up appstore-role RBAC tightening

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for deploying HeLx to Kubernetes.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.5.8
+version: 4.5.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 4.5.8](https://img.shields.io/badge/Version-4.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
+![Version: 4.5.9](https://img.shields.io/badge/Version-4.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 


### PR DESCRIPTION
## Summary
- Companion to helxplatform/appstore-chart#139, which tightens `appstore-role` to the verbs `tycho/kube.py` actually calls.
- The `appstore` dependency here is pinned as `"^5.1.1"`, which already admits the new `5.1.5` release — no dependency-line change needed.
- However, this repo's own subchart archive is resolved and bundled at publish time, not dynamically at install time, so an already-published `helx-chart` release stays frozen to whatever `appstore` version it last resolved. This bump exists purely to trigger a fresh `helm dependency update` + republish via CI so umbrella installs actually pick up the new `appstore` version.
- Chart version `4.5.6` → `4.5.7` (based on current `develop`, which already includes the unrelated resty service-name fix that bumped `4.5.5` → `4.5.6`).

## Test plan
- [ ] Merge after helxplatform/appstore-chart#139 is merged and published
- [ ] Confirm CI re-resolves `appstore` to `5.1.5` on publish